### PR TITLE
Allow URI escaping in any user/pass in the URL

### DIFF
--- a/lib/puppet/provider/apt_key/apt_key.rb
+++ b/lib/puppet/provider/apt_key/apt_key.rb
@@ -134,6 +134,12 @@ Puppet::Type.type(:apt_key).provide(:apt_key) do
         else
           user_pass = parsed_value.userinfo.split(':')
           parsed_value.userinfo = ''
+          unless user_pass.nil?
+            # URI unescape the username and password in case they had any special
+            # characters that required escaping
+            user_pass[0] = URI.unescape(user_pass[0])
+            user_pass[1] = URI.unescape(user_pass[1])
+          end
           key = open(parsed_value, http_basic_authentication: user_pass).read
         end
       rescue OpenURI::HTTPError, Net::FTPPermError => e


### PR DESCRIPTION
One of my providers distributes packages from behind a password protected repository. And email addresses have become very common usernames, and the '@' in a username won't work since the URL decoder will detect that as the end of the user:pass part. This trivial patch allows both the username and the password to be URI encoded.

I'm pretty sure that doing the URI un-escaping after splitting 'parsed_value' is the right thing, in case either includes a colon ':' character.